### PR TITLE
Remove archibaldmicrobrasserie.ca from list

### DIFF
--- a/.input_sources/hacked-malware-websites.txt
+++ b/.input_sources/hacked-malware-websites.txt
@@ -2035,7 +2035,6 @@ http://arcfestoheni.hu/n3usad
 http://archantilles.fr/afford.php?utm_source=5r2ke0ow6k&utm_medium=qqod2h9a88&utm_campaign=2d1hl235eg&utm_term=bagguzjrsj&utm_content=smadvzf6pu
 http://archbangla.com/jtr/AMAZON/cerrttsffr.htm
 http://archbangla.com/jutr/
-http://archibaldmicrobrasserie.ca/hjg766
 http://archilog.at/imwjmt
 http://architectureetenvironnement.ma/g31701d
 http://architekten-gm.de/nyx37ec


### PR DESCRIPTION
Remove archibaldmicrobrasserie.ca from list. The website belongs to a client of ours and was indeed hacked a few years ago but it has since been remade from scratch and moved to a new host.