### PR TITLE
Add localhost 127.0.0.1

### DIFF
--- a/hosts
+++ b/hosts
@@ -15,6 +15,7 @@
 # For Windows based systems this is placed either at
 # C:\windows\system32\drivers\etc\hosts
 # or C:\Windows\System32\drivers\etc\hosts
+127.0.0.1 localhost #[IPv4]
 ::1 localhost #[IPv6]
 # START HOSTS LIST ### DO NOT EDIT THIS LINE AT ALL ###
 0.0.0.0 00005ik.rcomhost.com


### PR DESCRIPTION
This is strange that the list contains just a record for localhost IPv6, but not for IPv4.

See the details here: https://github.com/AdguardTeam/AdGuardHome/issues/3790