### PR TITLE
Remove BarbadosToday.bb from the list.

### DIFF
--- a/.input_sources/hacked-malware-websites.txt
+++ b/.input_sources/hacked-malware-websites.txt
@@ -14970,7 +14970,6 @@ http://sb-11037.fastdl-server.biz/09uh8ny
 https://baggir.org/
 http://sbaky.com/873nf3g
 http://sbaky.com/rpveuev
-https://barbadostoday.bb/examine.php?utm_source=5r2ke0ow6k&utm_medium=qqod2h9a88&utm_campaign=2d1hl1v1r8&utm_term=k8xtgciqns&utm_content=68qxaz5k0l
 http://sbastrologer.com/t76f3g
 http://sbdma.com/ri3xnzkaoz
 https://bedrifg.org/


### PR DESCRIPTION
The [Barbados Today news website](https://barbadostoday.bb) became inaccessible when [NextDNS](https://nextdns.io/) started using this list. 

On examining `.input_sources/hacked-malware-websites.txt`, the  URL returned a 404 error page. 
Also, the list is 11 months old, so it is very likely that the issues were present in the past, but not anymore. 
Google continues to recommend News articles from this website, so I believe it is safe. 
